### PR TITLE
refactor(Makefile): use virtualenv to install our forked version of pygments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.pyc
 __pycache__
 /.vscode
+/.venv

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+VENVDIR := .venv
+export PATH := $(VENVDIR)/bin:$(PATH)
+
+install-deps:
+	test -d $(VENVDIR) || python3 -m venv $(VENVDIR)
+	pip install https://bitbucket.org/gebner/pygments-main/get/default.tar.gz#egg=Pygments
+	pip install sphinx
+
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/README.md
+++ b/README.md
@@ -1,24 +1,18 @@
 The Lean Reference Manual
 -------------------------
 
-The manual uses Sphinx and restructured text, and the Read the Docs theme.
+The manual uses Sphinx and restructured text.
 
 # How to build
 
+The build requires python 3.
+
 ```
-pip install sphinx recommonmark
+make install-deps
 make html
 ```
 
-The first line is only necessary if we eventually incorporate markdown files as well as restructured text.
-
-On OSX, after the El Capitan update, we need to install our own version of python, or use `--user` flag when installing `sphinx`.
-
-```
-pip install --user sphinx recommonmark
-pip install --user sphinx_rtd_theme
-make html
-```
+The call to `make install-deps` is only required the first time, and only if you want to use the bundled version of Sphinx and Pygments with improved syntax highlighting for Lean.
 
 # How to deploy
 

--- a/conf.py
+++ b/conf.py
@@ -68,7 +68,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.venv']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'


### PR DESCRIPTION
You don't even need mercurial!
And I can force everyone to use python 3, making my life a bit easier.
This should also simplify the installation on mac.

Just run `make install-deps` to use the bundled version of sphinx and pygments.
After that, `make html` and co. will pick it up automatically.